### PR TITLE
fixed null entity packet issue

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/dualwielding/network/PlayerAttackPacket.java
+++ b/src/main/java/net/dualwielding/network/PlayerAttackPacket.java
@@ -29,7 +29,9 @@ public class PlayerAttackPacket {
             ((PlayerAccess) player).setOffhandAttack();
           //  ((PlayerAccess) player).resetLastOffhandAttackTicks();
             player.updateLastActionTime();
-            player.attack(player.world.getEntityById(buffer.getInt(0)));
+            if (player.world.getEntityById(buffer.getInt(0)) != null) {
+            	player.attack(player.world.getEntityById(buffer.getInt(0)));
+            }
         });
 
     }


### PR DESCRIPTION
I believe this will fix #2, #6 and #7 plus their closed duplicates. Before I added the check for null, I would get this when attempting to dual wield hit the ender dragon:

> [11:23:31] [Netty Server IO #5/ERROR]: Encountered exception while handling in channel with name "dualwielding:attack_entity"
> java.lang.NullPointerException: Cannot invoke "net.minecraft.class_1297.method_5732()" because "target" is null
> 	at net.minecraft.class_1657.handler$zmi000$attackMixin(class_1657.java:5406) ~[intermediary-server.jar:?]
> 	at net.minecraft.class_1657.method_7324(class_1657.java) ~[intermediary-server.jar:?]
> 	at net.minecraft.class_3222.method_7324(class_3222.java:1406) ~[intermediary-server.jar:?]
> 	at net.dualwielding.network.PlayerAttackPacket.lambda$init$0(PlayerAttackPacket.java:32) ~[dualwielding-1.0.6.jar:?]
> 	at net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon.receive(ServerPlayNetworkAddon.java:89) ~[4a9749e8-d9ac-4757-9617-c684e6280003.jar:?]
> 	at net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon.receive(ServerPlayNetworkAddon.java:38) ~[4a9749e8-d9ac-4757-9617-c684e6280003.jar:?]
> 	at net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon.handle(AbstractChanneledNetworkAddon.java:100) [4a9749e8-d9ac-4757-9617-c684e6280003.jar:?]
> 	at net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon.handle(ServerPlayNetworkAddon.java:84) [4a9749e8-d9ac-4757-9617-c684e6280003.jar:?]
> 	at net.minecraft.class_3244.handler$bkp000$handleCustomPayloadReceivedAsync(class_3244.java:1672) [intermediary-server.jar:?]
> 	at net.minecraft.class_3244.method_12075(class_3244.java) [intermediary-server.jar:?]
> 	at net.minecraft.class_2817.method_12199(class_2817.java:38) [intermediary-server.jar:?]
> 	at net.minecraft.class_2817.method_11054(class_2817.java:7) [intermediary-server.jar:?]
> 	at net.minecraft.class_2535.method_10759(class_2535.java:163) [intermediary-server.jar:?]
> 	at net.minecraft.class_2535.method_10770(class_2535.java:150) [intermediary-server.jar:?]
> 	at net.minecraft.class_2535.channelRead0(class_2535.java:53) [intermediary-server.jar:?]
> 	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:297) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:413) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [intermediary-server.jar:?]
> 	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [intermediary-server.jar:?]
> 	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [intermediary-server.jar:?]
> 	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [intermediary-server.jar:?]
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [intermediary-server.jar:?]
> 	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965) [intermediary-server.jar:?]
> 	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163) [intermediary-server.jar:?]
> 	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:647) [intermediary-server.jar:?]
> 	at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:547) [intermediary-server.jar:?]
> 	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:501) [intermediary-server.jar:?]
> 	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:461) [intermediary-server.jar:?]
> 	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884) [intermediary-server.jar:?]
> 	at java.lang.Thread.run(Thread.java:833) [?:?]
> [11:23:31] [Server thread/INFO]: SalveMundiProd lost connection: Internal Exception: java.lang.NullPointerException: Cannot invoke "net.minecraft.class_1297.method_5732()" because "target" is null
> [11:23:31] [Server thread/INFO]: SalveMundiProd left the game

As it stands, this means my fix won't do anything to the ender dragon now, but that's a right sight better than a crash. My guess is that this has to do with weird mod compatibilities. My ender dragon is modded, so it probably isn't at the normal buffer position (0) when I go to hit it, or some other such similar issue.

Don't have time to properly fix this issue but at least you should now be on the right track! :)