### PR TITLE
Fixed network packet issue #9

### DIFF
--- a/src/main/java/net/dualwielding/network/PlayerAttackPacket.java
+++ b/src/main/java/net/dualwielding/network/PlayerAttackPacket.java
@@ -8,6 +8,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.medievalweapons.init.TagInit;
 import net.medievalweapons.item.Big_Axe_Item;
 import net.medievalweapons.item.Long_Sword_Item;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.Packet;
@@ -29,7 +30,7 @@ public class PlayerAttackPacket {
             ((PlayerAccess) player).setOffhandAttack();
           //  ((PlayerAccess) player).resetLastOffhandAttackTicks();
             player.updateLastActionTime();
-            if (player.world.getEntityById(buffer.getInt(0)) != null) {
+            if (!player.world.isClient && player.world.getEntityById(buffer.getInt(0)) != null) {
             	player.attack(player.world.getEntityById(buffer.getInt(0)));
             }
         });


### PR DESCRIPTION
Fixed network packet issue that was causing incompatibility with Immersive Portals and resolves issue #9 in dedicated servers as well as the integrated single player server